### PR TITLE
Add option to threshold in place

### DIFF
--- a/lib/adaptive-threshold.js
+++ b/lib/adaptive-threshold.js
@@ -6,11 +6,12 @@ function adaptiveThreshold (pixels, options = {}) {
   let {
     size = 7,
     compensation = 7,
-    singleChannel = false
+    singleChannel = false,
+    inPlace = false
   } = options
   let midSize = Math.floor(size / 2)
   let [width, height] = pixels.shape
-  let res = zeros([width, height])
+  let res = inPlace ? pixels : zeros([width, height])
 
   let grayscaled = singleChannel ? pixels : grayscale(pixels)
   let meanMatrix = localMean(grayscaled, size)


### PR DESCRIPTION
Some other ndarray modules work in place, like fill-array and fill-scan.
For simplicity this option only reuses the existing ndarray instead of creating a new one.
I don't tested it yet, but there's a chance of a bug in case singleChannel is true.
If so a check could be used of the implemented can be changed to consider this detail.